### PR TITLE
Change upstream provider of php-html-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "paquettg/php-html-parser": "~1",
+        "thesoftwarefanatics/php-html-parser": "~1",
         "illuminate/config": "~5"
     },
     "require-dev":{


### PR DESCRIPTION
paquettg/php-html-parser seems dead and does not work in PHP 7.1. I propose to use this fork instead.